### PR TITLE
Grizu-263 decoders added

### DIFF
--- a/grizu.py
+++ b/grizu.py
@@ -1,0 +1,63 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+from pkg_resources import parse_version
+import kaitaistruct
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+
+
+if parse_version(kaitaistruct.__version__) < parse_version('0.9'):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Grizu(KaitaiStruct):
+    def __init__(self, _io, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+        self._read()
+
+    def _read(self):
+        self.header = Grizu.Header(self._io, self, self._root)
+
+    class Header(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.teamid = (self._io.read_bytes(6)).decode(u"ASCII")
+            self.year = self._io.read_u1()
+            self.month = self._io.read_u1()
+            self.date = self._io.read_u1()
+            self.hour = self._io.read_u1()
+            self.minute = self._io.read_u1()
+            self.second = self._io.read_u1()
+            self.temp = self._io.read_u2le()
+            self.epstoobcina1_current = self._io.read_u2le()
+            self.epstoobcina1_busvoltage = self._io.read_u2le()
+            self.epsina2_current = self._io.read_u2le()
+            self.epsina2_busvoltage = self._io.read_u2le()
+            self.baseina3_current = self._io.read_u2le()
+            self.baseina3_busvoltage = self._io.read_u2le()
+            self.topina4_current = self._io.read_u2le()
+            self.topina4_busvoltage = self._io.read_u2le()
+            self.behindantenina5_current = self._io.read_u2le()
+            self.behindantenina5_busvoltage = self._io.read_u2le()
+            self.rightsideina6_current = self._io.read_u2le()
+            self.rightsideina6_busvoltage = self._io.read_u2le()
+            self.leftsideina7_current = self._io.read_u2le()
+            self.leftsideina7_busvoltage = self._io.read_u2le()
+            self.imumx = self._io.read_u2le()
+            self.imumy = self._io.read_u2le()
+            self.imumz = self._io.read_u2le()
+            self.imuax = self._io.read_u2le()
+            self.imuay = self._io.read_u2le()
+            self.imuaz = self._io.read_u2le()
+            self.imugx = self._io.read_u2le()
+            self.imugy = self._io.read_u2le()
+            self.imugz = self._io.read_u2le()
+
+
+
+

--- a/ksy/grizu.ksy
+++ b/ksy/grizu.ksy
@@ -1,0 +1,76 @@
+meta:
+  id: grizu
+  file-extension: grizu
+  endian: le
+seq:
+  - id: header
+    type: header
+
+types:
+  header:
+    seq:
+      - id: teamid
+        type: str
+        size: 6
+        encoding: ASCII
+      - id: year
+        type: u1
+      - id: month
+        type: u1
+      - id: date
+        type: u1
+      - id: hour
+        type: u1
+      - id: minute
+        type: u1
+      - id: second
+        type: u1
+      - id: temp
+        type: u2
+      - id: epstoobcina1_current
+        type: u2
+      - id: epstoobcina1_busvoltage
+        type: u2
+      - id: epsina2_current
+        type: u2
+      - id: epsina2_busvoltage
+        type: u2
+      - id: baseina3_current
+        type: u2
+      - id: baseina3_busvoltage
+        type: u2
+      - id: topina4_current
+        type: u2
+      - id: topina4_busvoltage
+        type: u2
+      - id: behindantenina5_current
+        type: u2
+      - id: behindantenina5_busvoltage
+        type: u2
+      - id: rightsideina6_current
+        type: u2
+      - id: rightsideina6_busvoltage
+        type: u2
+      - id: leftsideina7_current
+        type: u2
+      - id: leftsideina7_busvoltage
+        type: u2
+      - id: imumx
+        type: u2
+      - id: imumy
+        type: u2
+      - id: imumz
+        type: u2
+      - id: imuax
+        type: u2
+      - id: imuay
+        type: u2
+      - id: imuaz
+        type: u2
+      - id: imugx
+        type: u2
+      - id: imugy
+        type: u2
+      - id: imugz
+        type: u2
+


### PR DESCRIPTION
KSY and Python decoders for Grizu-263 satellite added to repository. Tested using locally generated binay files. (TA7W/OH2UDS)